### PR TITLE
Fix `./manage.py createsuperuser`

### DIFF
--- a/siwe_auth/backend.py
+++ b/siwe_auth/backend.py
@@ -40,7 +40,7 @@ def _nonce_is_valid(nonce: str) -> bool:
 
 class SiweBackend(BaseBackend):
     """
-    Authenticate an Ethereum address as per Sing-In with Ethereum (EIP-4361).
+    Authenticate an Ethereum address as per Sign-In with Ethereum (EIP-4361).
     """
 
     def authenticate(self, request, signature: str = None, siwe_message: SiweMessage = None):

--- a/siwe_auth/models.py
+++ b/siwe_auth/models.py
@@ -30,7 +30,7 @@ class WalletManager(BaseUserManager):
         wallet.save(using=self._db)
         return wallet
 
-    def create_superuser(self, ethereum_address: str):
+    def create_superuser(self, ethereum_address: str, password: str):
         """
         Creates and saves a superuser with the given ethereum address.
         """


### PR DESCRIPTION
When I run `./manage.py createsuperuser` I get an error:

```
(eth3) [peterconerly@secretproject]$ ./manage.py createsuperuser
Ethereum address: 0xmyethaddr
Password: 
Password (again): 
Traceback (most recent call last):
  File "/Users/peterconerly/code/secretproject/./manage.py", line 22, in <module>
    main()
  File "/Users/peterconerly/code/secretproject/./manage.py", line 18, in main
    execute_from_command_line(sys.argv)
  File "/Users/peterconerly/.virtualenvs/eth3/lib/python3.10/site-packages/django/core/management/__init__.py", line 446, in execute_from_command_line
    utility.execute()
  File "/Users/peterconerly/.virtualenvs/eth3/lib/python3.10/site-packages/django/core/management/__init__.py", line 440, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/peterconerly/.virtualenvs/eth3/lib/python3.10/site-packages/django/core/management/base.py", line 414, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/peterconerly/.virtualenvs/eth3/lib/python3.10/site-packages/django/contrib/auth/management/commands/createsuperuser.py", line 87, in execute
    return super().execute(*args, **options)
  File "/Users/peterconerly/.virtualenvs/eth3/lib/python3.10/site-packages/django/core/management/base.py", line 460, in execute
    output = self.handle(*args, **options)
  File "/Users/peterconerly/.virtualenvs/eth3/lib/python3.10/site-packages/django/contrib/auth/management/commands/createsuperuser.py", line 232, in handle
    self.UserModel._default_manager.db_manager(database).create_superuser(
TypeError: WalletManager.create_superuser() got an unexpected keyword argument 'password'
```

I was able to fix it by adding `password` as an (ignored) parameter to `WalletManager.create_superuser` but this feels like a pretty inelegant solution.

I'm also not clear how the command `createsuperuser` is modified from Django. (And how did Django know to ask for the Ethereum address field?)

Creating a superuser also didn't trigger data fetch from an ethereum data provider, but that's probably fine. :D 

Is there a better way to fix this bug? (And is this hacky solution going to fail some future `mypy` type-checking or linting?)