### PR TITLE
Create ens profile setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,4 +151,8 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# javascript modules
 node_modules
+
+# osx
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -359,9 +359,18 @@ fetch('/api/authentication/nonce', {
 
 
 ### Configuring Your Project
-TODO: Define required and optional configuration variables for project's `settings.py`
 
-
+#### django-siwe-auth specific options in settings.py:
+```py
+AUTH_USER_MODEL = "siwe_auth.Wallet" # required for siwe as the default authentication
+AUTHENTICATION_BACKENDS = ["siwe_auth.backend.SiweBackend"] # required for siwe as the default authentication
+LOGIN_URL = "/" # optional, django's default is "/accounts/login/"
+SESSION_COOKIE_AGE = 3 * 60 * 60 # Age of cookie, in seconds. Optional, django's default is weeks.
+CREATE_GROUPS_ON_AUTHN = True # optional, default is False
+CREATE_ENS_PROFILE_ON_AUTHN = True # optional, default is True
+CUSTOM_GROUPS = [] # optional, see "Adding a Group" below
+PROVIDER = "https://mainnet.infura.io/v3/..." # Required if CREATE_GROUPS_ON_AUTHN or CREATE_ENS_PROFILE_ON_AUTHN are True. Optional otherwise. Any ethereum API key (infura or alchemy) will work.
+```
 
 
 <!-- USAGE EXAMPLES -->

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Requirements for using `django-siwe-auth` in a Django application:
    AUTHENTICATION_BACKENDS = ["siwe_auth.backend.SiweBackend"]
    LOGIN_URL = "/"
    SESSION_COOKIE_AGE = 3 * 60 * 60 
-   CREATE_GROUPS_ON_AUTHN = True # defaults to False
+   CREATE_GROUPS_ON_AUTHN = False # defaults to False
    CREATE_ENS_PROFILE_ON_AUTHN = True # defaults to True
    CUSTOM_GROUPS = [
        ('ens_owners', ERC721OwnerManager(config={'contract': '0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85'})),
@@ -360,12 +360,19 @@ fetch('/api/authentication/nonce', {
 
 ### Configuring Your Project
 
-#### django-siwe-auth specific options in settings.py:
+#### Relevant native Django settings
+
 ```py
+# in settings.py
 AUTH_USER_MODEL = "siwe_auth.Wallet" # required for siwe as the default authentication
 AUTHENTICATION_BACKENDS = ["siwe_auth.backend.SiweBackend"] # required for siwe as the default authentication
 LOGIN_URL = "/" # optional, django's default is "/accounts/login/"
 SESSION_COOKIE_AGE = 3 * 60 * 60 # Age of cookie, in seconds. Optional, django's default is weeks.
+```
+
+#### django-siwe-auth specific settings
+```py
+# in settings.py
 CREATE_GROUPS_ON_AUTHN = True # optional, default is False
 CREATE_ENS_PROFILE_ON_AUTHN = True # optional, default is True
 CUSTOM_GROUPS = [] # optional, see "Adding a Group" below

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Requirements for using `django-siwe-auth` in a Django application:
    AUTHENTICATION_BACKENDS = ["siwe_auth.backend.SiweBackend"]
    LOGIN_URL = "/"
    SESSION_COOKIE_AGE = 3 * 60 * 60 
+   CREATE_GROUPS_ON_AUTHN = True # defaults to False
+   CREATE_ENS_PROFILE_ON_AUTHN = True # defaults to True
    CUSTOM_GROUPS = [
        ('ens_owners', ERC721OwnerManager(config={'contract': '0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85'})),
        ('bayc_owners', ERC721OwnerManager(config={'contract': '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D'})),

--- a/examples/notepad/notepad/settings.py
+++ b/examples/notepad/notepad/settings.py
@@ -37,6 +37,7 @@ AUTHENTICATION_BACKENDS = ["siwe_auth.backend.SiweBackend"]
 LOGIN_URL = "/"
 SESSION_COOKIE_AGE = 3 * 60 * 60
 CREATE_GROUPS_ON_AUTHN = True
+CREATE_ENS_PROFILE_ON_AUTHN = True
 CUSTOM_GROUPS = [
     (
         "ens",

--- a/siwe_auth/backend.py
+++ b/siwe_auth/backend.py
@@ -143,8 +143,8 @@ class ENSProfile:
     Container for ENS profile information including but not limited to primary name and avatar.
     """
 
-    name: str = ""
-    avatar: str = ""
+    name: str = None
+    avatar: str = None
 
     def __init__(self, ethereum_address: str, w3: Web3):
         # Temporary until https://github.com/ethereum/web3.py/pull/2286 is merged


### PR DESCRIPTION
This would solve my issue https://github.com/payton/django-siwe-auth/issues/19

I added an option, CREATE_ENS_PROFILE_ON_AUTHN. I tried to emulate CREATE_GROUPS_ON_AUTHN without changing the current behavior for django-siwe-auth users, which is why I default CREATE_ENS_PROFILE_ON_AUTHN to True in backends.py.

I also added some documentation to README.md, but you could cherry-pick that commit and remove a line to include it without the rest of the code here.