### PR TITLE
Minimal test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+test:
+	DJANGO_SETTINGS_MODULE=examples.notepad.notepad.settings \
+		python -m django test $${TEST_ARGS:-tests}
+

--- a/examples/notepad/notepad/settings.py
+++ b/examples/notepad/notepad/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
 from pathlib import Path
+import sys
 
 from siwe_auth.custom_groups.erc721 import ERC721OwnerManager
 from siwe_auth.custom_groups.erc1155 import ERC1155OwnerManager
@@ -18,6 +19,9 @@ from siwe_auth.custom_groups.erc1155 import ERC1155OwnerManager
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+
+sys.path.append(str(BASE_DIR)) # used for tests
+# the notepad.settings app is the example app useds in tests.py
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ django-ratelimit = "^3.0.1"
 black = "^21.12b0"
 pytest = "^6.2.5"
 flake8 = "^4.0.1"
+eth-account = "^0.5.6"
+pyhumps = "^3.5.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/siwe_auth/tests.py
+++ b/siwe_auth/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/tests/test_siwe_auth.py
+++ b/tests/test_siwe_auth.py
@@ -1,0 +1,78 @@
+import json
+from os import path
+
+from django.test import TestCase, Client
+from eth_account import Account, messages
+from humps import decamelize
+import pytest
+from siwe.siwe import SiweMessage, ValidationError
+
+
+BASE_TESTS = path.join("examples", "notepad", "siwe", "test")
+with open(path.join(BASE_TESTS, "parsing_positive.json"), "r") as f:
+    parsing_positive = decamelize(json.load(fp=f))
+with open(path.join(BASE_TESTS, "parsing_negative.json"), "r") as f:
+    parsing_negative = decamelize(json.load(fp=f))
+with open(path.join(BASE_TESTS, "validation_negative.json"), "r") as f:
+    validation_negative = decamelize(json.load(fp=f))
+with open(path.join(BASE_TESTS, "validation_positive.json"), "r") as f:
+    validation_positive = decamelize(json.load(fp=f))
+
+
+class ApiTests(TestCase):
+
+    def test_nonce(self):
+        nonce_response = self.client.get('/api/auth/nonce')
+        self.assertEqual(nonce_response.status_code, 200)
+        nonce_content = json.loads(nonce_response.content)
+        self.assertTrue('nonce' in nonce_content)
+
+
+class SigningClientApiTest(TestCase):
+    account = None
+    
+    def setUp(self):
+        self.account = Account.create()
+
+    def getNonce(self):
+        nonce_response = self.client.get('/api/auth/nonce')
+        nonce_content = json.loads(nonce_response.content)
+        return nonce_content['nonce']
+
+    def test_fails_without_nonce(self):
+        # todo: same as below but without nonce
+        pass 
+
+    def test_message_round_trip(self):
+        for test_name, test in parsing_positive.items():
+            message = SiweMessage(test["fields"])
+            message.address = self.account.address
+
+            nonce = self.getNonce()
+            message.nonce = nonce
+
+            message_obj = {}
+            for slot in message.__slots__:
+                slotvalue = getattr(message, slot, None)
+                if slotvalue is not None:
+                    message_obj[slot] = slotvalue
+
+            signature = self.account.sign_message(
+                messages.encode_defunct(text=message.prepare_message())
+            ).signature
+
+            headers = {
+                'content_type': 'application/json',
+            }
+
+            sig = signature.hex()
+            loginAttemptResponse = self.client.post("/api/auth/login", {
+                'message': message_obj,
+                'signature': sig
+            }, **headers)
+            
+
+            print('loginAttemptResponse', loginAttemptResponse)
+            
+            # fails because of infura key access denied
+            # requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://mainnet.infura.io/v3/69bbfab4edd94ae0ae6a78d63f908d42

--- a/tests/test_siwe_auth.py
+++ b/tests/test_siwe_auth.py
@@ -5,7 +5,6 @@ import django.conf as conf
 from django.test import TestCase, Client
 from eth_account import Account, messages
 from humps import decamelize
-import pytest
 from siwe.siwe import SiweMessage, ValidationError
 from siwe_auth.models import Nonce
 


### PR DESCRIPTION
Hey @payton 

I needed to figure out how to test siwe-auth in the codebase I'm working on, so this project is the beneficiary of that!

I borrowed a lot from `siwe-py`'s tests. Here's a few choices I made to think about:

- These tests uses the notepad app as the django test app.
- These tests require the `examples/notepad/siwe` submodule to be installed, since I'm using their `validation_positive.json` test data
- `pytest` doesn't play nicely with `django.test.TestCase`, so instead of using `pytest.mark.parametrize` like `siwe-py` does, I simply for looped. In a scenario where multiple of those tests break, these tests would only print out errors from the first failure
- Added `humps` to `decamelize` like `siwe-py` does.
- Only tested the success cases and the "missing nonce" test case
- I added a `Makefile` with the test command
