### PR TITLE
Add `auto_add_now=True` to `Wallet.created`

### DIFF
--- a/siwe_auth/backend.py
+++ b/siwe_auth/backend.py
@@ -98,7 +98,6 @@ class SiweBackend(BaseBackend):
                 ethereum_address=Web3.toChecksumAddress(siwe_message.address),
                 ens_name=ens_profile.name,
                 ens_avatar=ens_profile.avatar,
-                created=now,
                 last_login=now,
                 password=None,
             )

--- a/siwe_auth/models.py
+++ b/siwe_auth/models.py
@@ -25,7 +25,6 @@ class WalletManager(BaseUserManager):
 
         wallet = self.model()
         wallet.ethereum_address = ethereum_address
-        wallet.created = datetime.now()
 
         wallet.save(using=self._db)
         return wallet
@@ -54,7 +53,7 @@ class Wallet(AbstractBaseUser, PermissionsMixin):
     )
     ens_name = models.CharField(max_length=255, blank=True, null=True)
     ens_avatar = models.CharField(max_length=255, blank=True, null=True)
-    created = models.DateTimeField("datetime created")
+    created = models.DateTimeField("datetime created", auto_now_add=True)
     is_active = models.BooleanField(default=True)
     is_admin = models.BooleanField(default=False)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,17 @@
+import datetime
+
+import pytz
+
+from django.test import TestCase
+from eth_account import Account
+
+from siwe_auth.models import Wallet
+
+class WalletTests(TestCase):
+
+    def test_created(self):
+        now = datetime.datetime.now(tz=pytz.UTC)
+        account = Account.create()
+        wallet = Wallet.objects.create(ethereum_address=account.address)
+        diff = wallet.created - now
+        self.assertTrue(diff < datetime.timedelta(seconds=1))


### PR DESCRIPTION
Use django's built-in [`auto_now_add`](https://docs.djangoproject.com/en/4.0/ref/models/fields/#django.db.models.DateField.auto_now_add) option on `Wallet.created`. This helps makes using `Wallet.objects.create` a little nicer and keeps the same behavior that was probably intended in the project.

I added this commit ontop of the "minimal tests" branch, so rebasing might be needed if that branch changes before it's merged.