### PR TITLE
__str__ should return a string

### DIFF
--- a/examples/notepad/app/models.py
+++ b/examples/notepad/app/models.py
@@ -11,7 +11,7 @@ class Notepad(models.Model):
     value = models.TextField()
 
     def __str__(self):
-        return {self.wallet.ethereum_address: self.value}
+        return str({self.wallet.ethereum_address: self.value})
 
 
 class SharedNotepad(models.Model):
@@ -19,4 +19,4 @@ class SharedNotepad(models.Model):
     value = models.TextField()
 
     def __str__(self):
-        return {self.name: self.value}
+        return str({self.name: self.value})


### PR DESCRIPTION
While using the django admin panel, I was getting an error:

```
TypeError at /admin/app/sharednotepad/add/
__str__ returned non-string (type dict)
```

I don't _think_ the dictionary-string is used functionally anywhere? I checked `views.py` and casting Notepad or SharedNotepad as a string doesn't happen.

I also tested manually by editing a notepad.