### PR TITLE
Move ValidationError to bottom of except chain

### DIFF
--- a/siwe_auth/backend.py
+++ b/siwe_auth/backend.py
@@ -62,9 +62,6 @@ class SiweBackend(BaseBackend):
 
         try:
             siwe_message.validate(signature=signature, provider=w3)
-        except ValidationError:
-            logging.info("Authentication attempt rejected due to invalid message.")
-            return None
         except ExpiredMessage:
             logging.info("Authentication attempt rejected due to expired message.")
             return None
@@ -75,6 +72,9 @@ class SiweBackend(BaseBackend):
             return None
         except InvalidSignature:
             logging.info("Authentication attempt rejected due to invalid signature.")
+            return None
+        except ValidationError:
+            logging.info("Authentication attempt rejected due to invalid message.")
             return None
 
         # Validate nonce


### PR DESCRIPTION
ExpiredMessage, MalformedSession, and InvalidSignature are all children of ValidationError. As a result, they were previously unreachable.

https://github.com/spruceid/siwe-py/blob/main/siwe/siwe.py#L16-L37