### PR TITLE
Move request.body call up to view

### DIFF
--- a/siwe_auth/backend.py
+++ b/siwe_auth/backend.py
@@ -1,7 +1,5 @@
-import json
 import datetime
 import logging
-import re
 from typing import Optional
 
 import pytz
@@ -44,18 +42,7 @@ class SiweBackend(BaseBackend):
     Authenticate an Ethereum address as per Sign-In with Ethereum (EIP-4361).
     """
 
-    def authenticate(self, request, signature: str = None, siwe_message: SiweMessage = None):
-        body = json.loads(request.body)
-
-        if siwe_message is None:
-            siwe_message = SiweMessage(
-                message={
-                    re.sub(r"(?<!^)(?=[A-Z])", "_", k).lower(): v
-                    for k, v in body["message"].items()
-                }
-            )
-            signature = body["signature"]
-
+    def authenticate(self, request, signature: str, siwe_message: SiweMessage):
         # Validate signature
         w3 = Web3(HTTPProvider(settings.PROVIDER))
         w3.middleware_onion.inject(geth_poa_middleware, layer=0)

--- a/siwe_auth/views.py
+++ b/siwe_auth/views.py
@@ -26,7 +26,7 @@ def login(request):
     body = json.loads(request.body)
     auth_kwargs = {
         "siwe_message": SiweMessage(
-            message=_dictSnakeCaseToCamelCase(body["message"])
+            message=_dict_camel_case_to_snake_case(body["message"])
         ),
         "signature": body["signature"]
     }
@@ -72,7 +72,7 @@ def nonce(request):
     return JsonResponse({"nonce": n.value})
 
 
-def _dictSnakeCaseToCamelCase(data: dict) -> dict:
+def _dict_camel_case_to_snake_case(data: dict) -> dict:
     """Converts keys in dictionary from camel case to snake case
     """
     return {

--- a/siwe_auth/views.py
+++ b/siwe_auth/views.py
@@ -26,10 +26,7 @@ def login(request):
     body = json.loads(request.body)
     auth_kwargs = {
         "siwe_message": SiweMessage(
-            message={
-                re.sub(r"(?<!^)(?=[A-Z])", "_", k).lower(): v
-                for k, v in body["message"].items()
-            }
+            message=_dictSnakeCaseToCamelCase(body["message"])
         ),
         "signature": body["signature"]
     }
@@ -73,6 +70,15 @@ def nonce(request):
     n.save()
 
     return JsonResponse({"nonce": n.value})
+
+
+def _dictSnakeCaseToCamelCase(data: dict) -> dict:
+    """Converts keys in dictionary from camel case to snake case
+    """
+    return {
+        re.sub(r"(?<!^)(?=[A-Z])", "_", k).lower(): v
+        for k, v in data.items()
+    }
 
 
 def _scrub_nonce():


### PR DESCRIPTION
I'm trying to use django-siwe-auth as the backend for django-rest-framework-simplejwt. It turns out that we can't access request.body after request.data. After the first time, an error is thrown
`django.http.request.RawPostDataException: You cannot access body after reading from request's data stream`

This is because simplejwt accesses request.data in the view https://github.com/jazzband/djangorestframework-simplejwt/blob/1f3e73d103d8b41e81aa4eccba1844312fa09345/rest_framework_simplejwt/views.py#L40

Related (not simple jwt): https://github.com/encode/django-rest-framework/issues/2774

I think it makes sense to move request formatting up to the view level before passing it on to the backend.