### PR TITLE
Fixed db migration error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,9 +60,7 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
-
-# migrations in example apps
-examples/**/migrations/*.py
+examples/**/migrations/0*.py
 
 # Flask stuff:
 instance/


### PR DESCRIPTION
Changed gitignore file to allow migrations folders, to avoid the need of running multiple makemigration commands. Fixes #49.